### PR TITLE
fix: prevent tag text from wrapping on mobile

### DIFF
--- a/src/components/PreviewItem.astro
+++ b/src/components/PreviewItem.astro
@@ -33,7 +33,7 @@ const postDate = format(date, "MMM d, yyyy");
       </p>
     )
   }
-  <div class="flex flex-row">
+  <div class="flex flex-row flex-wrap gap-y-2">
     {
       post.frontmatter.tags.map((tag) => (
         <a href={`/tags/${tag}`} class="category-tag">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -104,7 +104,7 @@ const paginationProps = {
   <div class="mt-10">
     {
       tags?.length && (
-        <ul class="flex items-center py-4">
+        <ul class="flex flex-wrap items-center gap-y-2 py-4">
           {tags.map((tag: string) => (
             <li>
               <a

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -97,7 +97,7 @@
 	}
 
 	.category-tag {
-		@apply inline-block border border-primary cursor-pointer text-primary rounded-md text-[10px] px-2 font-semibold transition-all ease-in-out uppercase hover:bg-primary hover:text-surface mr-2;
+		@apply inline-block border border-primary cursor-pointer text-primary rounded-md text-[10px] px-2 font-semibold transition-all ease-in-out uppercase hover:bg-primary hover:text-surface mr-2 whitespace-nowrap;
 	}
 
 	blockquote > p::before, blockquote > p::after {


### PR DESCRIPTION
## Problem
On mobile, the text inside tags was wrapping to multiple lines instead of the tags wrapping to a new line as a unit.

## Solution
1. Added `whitespace-nowrap` to `.category-tag` class in `global.css` - this prevents text inside individual tags from breaking
2. Added `flex-wrap` to tag containers in `PreviewItem.astro` and `BlogPost.astro` - this allows tags to wrap to new lines
3. Added `gap-y-2` for proper vertical spacing when tags wrap

## Expected Behavior
- Tags wrap to a new line as complete units
- Text inside each tag stays on a single line
- Proper spacing between wrapped rows of tags